### PR TITLE
Add an interactive init command

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -1,0 +1,99 @@
+package init
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/openshift/occ/pkg/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+const (
+	OCMUsernamePrompt        = `Provide your ocm user name`
+	OfflineAccessTokenPrompt = `Provide your OCM Offline Access Token from https://cloud.redhat.com/openshift/token`
+	OpsUtilsDirPrompt        = `(Optional) Provide your ops-sop/v4/utils directory.
+This is an absolute path to any necessary scripts you wish to have automatically mounted into your container.
+This is mounted in the "/root/sop_utils" directory in the container.`
+	OpsUtilsDirRwPrompt   = `Would you like the ops-sop directory to be mounted as readonly? [y/N]`
+	WaitingForUserInput   = `: `
+	OCMUserKey            = "ocm_user"
+	OfflineAccessTokenKey = "offline_access_token"
+	OpsUtilsDirKey        = "ops_utils_dir"
+	OpsUtilsDirRWKey      = "ops_utils_dir_rw"
+)
+
+func NewInitCmd() *cobra.Command {
+	var initCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initializes OCM container configuration",
+		Long: `init will create a config file at ~/.config/occ/config.yaml.
+If a config.yaml file already exists, you will be asked if you want to overwrite it or exit out.`,
+		Run: setupConfig,
+	}
+	return initCmd
+}
+
+func setupConfig(*cobra.Command, []string) {
+	reader := bufio.NewReader(os.Stdin)
+
+	configPath := config.Config.ConfigFileUsed()
+	if _, err := os.Stat(configPath); err == nil {
+		if value := Prompt(fmt.Sprintf("A config file already exists at %v, would you like to overwrite it? [y/N]", configPath), reader); strings.EqualFold(value, "y") {
+			fmt.Println("The configuration file will be overwritten.")
+			fmt.Println()
+		} else {
+			return
+		}
+	}
+
+	ocmUser := Prompt(OCMUsernamePrompt, reader)
+	config.Config.Set(OCMUserKey, ocmUser)
+	fmt.Println()
+
+	offlineAccessToken := Prompt(OfflineAccessTokenPrompt, reader)
+	config.Config.Set(OfflineAccessTokenKey, offlineAccessToken)
+	fmt.Println()
+
+	opsUtilsDir := Prompt(OpsUtilsDirPrompt, reader)
+	config.Config.Set(OpsUtilsDirKey, opsUtilsDir)
+
+	if opsUtilsDir != "" {
+		fmt.Println()
+		if value := Prompt(OpsUtilsDirRwPrompt, reader); strings.EqualFold(value, "n") {
+			config.Config.Set(OpsUtilsDirRWKey, true)
+		} else {
+			config.Config.Set(OpsUtilsDirRWKey, false)
+		}
+	}
+
+	_, err := os.Stat(config.DefaultConfigFileLocation)
+	if err != nil {
+		err := os.MkdirAll(config.DefaultConfigFileLocation, 0755)
+		if err != nil {
+			log.Trace(err)
+			log.Fatal("Failed to create necessary path for config file.")
+		}
+	}
+
+	err = config.Config.WriteConfig()
+	if err != nil {
+		log.Trace(err)
+		log.Fatal("Writing the config failed")
+	}
+
+	fmt.Printf("Config file has been written to %v:\n", configPath)
+}
+
+type reader interface {
+	ReadString(byte) (string, error)
+}
+
+func Prompt(prompt string, reader reader) string {
+	fmt.Println(prompt)
+	fmt.Print(WaitingForUserInput)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSuffix(input, "\n")
+	return input
+}

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -1,0 +1,29 @@
+package init
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestPrompt(t *testing.T) {
+	type test struct {
+		name  string
+		input string
+		want  string
+	}
+
+	tests := []test{
+		{name: "single word", input: "test", want: "test"},
+		{name: "multi word", input: "multiple words, with punctuation!", want: "multiple words, with punctuation!"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Prompt(tc.input, bufio.NewReader(bytes.NewBufferString(tc.input)))
+			if result != tc.want {
+				t.Fatalf(`Expected "%v", got "%v"`, tc.want, result)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	initCmd "github.com/openshift/occ/cmd/init"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -49,7 +50,7 @@ func NewRootCmd() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			config.InitConfig(cmd, cfgFile)
 
-			logcfg.ToggleDebug(verbosity, cmd.Flags().Changed("verbosity"))
+			_ = logcfg.ToggleDebug(verbosity, cmd.Flags().Changed("verbosity"))
 
 			// We're specifically checking this after the logcfg toggle so we don't always
 			// print the debug line if there's a config file
@@ -77,7 +78,7 @@ func NewRootCmd() *cobra.Command {
 	// Defines the logging verbosity level.  Default is set to 'warn'.
 	rootCmd.PersistentFlags().StringVarP(&verbosity, "verbosity", "v", "warn", "Log Level")
 
-	rootCmd.AddCommand(extension.NewVersionCobraCmd())
+	rootCmd.AddCommand(extension.NewVersionCobraCmd(), initCmd.NewInitCmd())
 
 	return rootCmd
 }
@@ -115,5 +116,5 @@ func checkForUpdates(cmd *cobra.Command, config *viper.Viper) {
 		return
 	}
 
-	fmt.Fprint(cmd.OutOrStderr(), out)
+	_, _ = fmt.Fprint(cmd.OutOrStderr(), out)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,7 @@ func InitConfig(cmd *cobra.Command, cfgFile string) {
 		v.SetConfigName("config")
 	}
 	// If a config file is found, read it in.
-	v.ReadInConfig()
+	_ = v.ReadInConfig()
 
 	// Set any necessary defaults for things that may not always be set via flags
 	setDefaults(v)


### PR DESCRIPTION
This PR adds a new command, `init` that walks the user through an interactive command line wizard to initialize their ocm container config.  the file is created at `~/.config/ocm-container/config.yaml`.

To try it out for yourself, you can pull down this branch, run `go build` from the root directory, and then run `./ocm-container init`.  A sample output is as follows:

```
alexvulaj@avulaj-mac ocm-container-v2 % ./ocm-container init
A config file already exists at /Users/alexvulaj/.config/ocm-container/config.yaml, would you like to overwrite it? [y/N]
: y
The configuration file will be overwritten.

Provide your ocm user name
: avulaj

Provide your OCM Offline Access Token from https://cloud.redhat.com/openshift/token
: my_token

(Optional) Provide your ops-sop/v4/utils directory.
This is an absolute path to any necessary scripts you wish to have automatically mounted into your container.
This is mounted in the "/root/sop_utils" directory in the container.
: 
Config file has been written to /Users/alexvulaj/.config/ocm-container/config.yaml:
container_subsystem: podman
cli: ocm
ocm_url: ""
ocm_user: avulaj
default_velero_ns: openshift-velero
offline_access_token: my_token
ops_utils_dir: ""
ops_utils_dir_rw: false
```