### PR TITLE
Adds podman-socket helpers to config.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ When Contributing to occ, please keep the following practices in mind:
     1. When we use the logging library to print debug or other output, it's automatically written to stderr (and makes the output parsable by next processes) and the end-user can hide any log levels they don't want to see with the -v flag.
 1. Use viper for any user-configurable flags or defaults
     1. This lets the end-user add things to their config file that otherwise would be flags they always want to run, or allows them to set multiple config files for separate scenarios, etc.  Viper also gives us automatic ENV var parsing for the flags as well, so the arg parsing order ends up being `viper defaults -> config file -> env vars -> arg flags`.
+
+
+When contributing on MacOS, in order to build the binary you will also need the following package installed from brew:
+
+```
+brew install gpgme
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -18,15 +19,21 @@ var (
 	// For example, --number is bound to PREFIX_NUMBER.
 	envPrefix = "OCC"
 
+	// The User's Home Directory
+	homeDir string
+
 	// DefaultConfigFileLocation is an exported value to use for help docs around the CLI utility
 	DefaultConfigFileLocation string
 )
 
 func init() {
 	// Find home directory.
-	home, err := os.UserHomeDir()
+	var err error
+	homeDir, err = os.UserHomeDir()
 	cobra.CheckErr(err)
-	configPath := fmt.Sprintf("%s/.config/occ", home)
+
+	// Look here for default config file. Can be overridden by end-user via flag
+	configPath := fmt.Sprintf("%s/.config/occ", homeDir)
 	DefaultConfigFileLocation = configPath
 }
 
@@ -64,6 +71,28 @@ func InitConfig(cmd *cobra.Command, cfgFile string) {
 func setDefaults(v *viper.Viper) {
 	v.SetDefault("release-endpoint", "https://api.github.com/repos/iamkirkbater/ocm-container-v2/releases/latest")
 	v.SetDefault("disable-update-checks", false)
+	v.SetDefault("container-image-tag", "latest")
+
+	// Set Defaults for various platforms
+	setLinuxDefaults(v)
+	setMacDefaults(v)
+}
+
+func setLinuxDefaults(v *viper.Viper) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	v.SetDefault("podman-socket", "unix://run/podman/podman.sock")
+}
+
+func setMacDefaults(v *viper.Viper) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+
+	// Assumes podman machine default. could potentially change this in the future.
+	v.SetDefault("podman-socket", fmt.Sprintf("%s/.local/share/containers/podman/machine/podman-machine-default/podman.sock", homeDir))
 }
 
 // Bind each cobra flag to its associated viper configuration (config file and environment variable)


### PR DESCRIPTION
Adds a helper to the config to get the default podman socket and adds some extra MacOS instructions to the readme.