### PR TITLE
Add short sentence about build reqs on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ When contributing on MacOS, in order to build the binary you will also need the 
 ```
 brew install gpgme
 ```
+
+When building on linux, make sure to install the podman build dependencies from [podman.io/.../build-dependencies](https://podman.io/getting-started/installation#build-and-run-dependencies).


### PR DESCRIPTION
Make sure to mention that building on linux also requires some dependencies to be installed. In my case, i faced the following error when running `go build`:

```
# pkg-config --cflags  -- gpgme
Package gpgme was not found in the pkg-config search path.
Perhaps you should add the directory containing `gpgme.pc'
to the PKG_CONFIG_PATH environment variable
Package 'gpgme', required by 'virtual:world', not found
pkg-config: exit status 1
# pkg-config --cflags  -- devmapper
Package devmapper was not found in the pkg-config search path.
Perhaps you should add the directory containing `devmapper.pc'
to the PKG_CONFIG_PATH environment variable
Package 'devmapper', required by 'virtual:world', not found
pkg-config: exit status 1
# github.com/containers/storage/drivers/btrfs
../../../go/pkg/mod/github.com/containers/storage@v1.43.0/drivers/btrfs/btrfs.go:9:10: fatal error: btrfs/ioctl.h: No such file or directory
    9 | #include <btrfs/ioctl.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```

Which is fixed by installing the dependencies required to build podman.